### PR TITLE
Appended note on long int size

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -211,9 +211,9 @@ platform-dependent.
 +--------+--------------------------+--------------------+----------------+------------+
 | ``I``  | :c:type:`unsigned int`   | integer            | 4              | \(2)       |
 +--------+--------------------------+--------------------+----------------+------------+
-| ``l``  | :c:type:`long`           | integer            | 4              | \(2)       |
+| ``l``  | :c:type:`long`           | integer            | 4              | \(2), \(7) |
 +--------+--------------------------+--------------------+----------------+------------+
-| ``L``  | :c:type:`unsigned long`  | integer            | 4              | \(2)       |
+| ``L``  | :c:type:`unsigned long`  | integer            | 4              | \(2), \(7) |
 +--------+--------------------------+--------------------+----------------+------------+
 | ``q``  | :c:type:`long long`      | integer            | 8              | \(2)       |
 +--------+--------------------------+--------------------+----------------+------------+
@@ -289,6 +289,11 @@ Notes:
    typical machine, an unsigned short can be used for storage, but not for math
    operations. See the Wikipedia page on the `half-precision floating-point
    format <half precision format_>`_ for more information.
+
+(7)
+   The "long integer" type is defined as a 4 byte type on both Windows OSs and
+   UNIX 32bit OSs, however UNIX 64bit OSs define the "long integer" type as an
+   8 byte type.
 
 
 A format character may be preceded by an integral repeat count.  For example,


### PR DESCRIPTION
While porting a Python app from Windows to Linux, I came across this as my code raised an exception asking for an 8 byte buffer to unpack into a long integer on Linux 64bit, while on Windows it ran fine.

check this link: https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.0.0/com.ibm.mq.ref.dev.doc/q104610_.htm

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
